### PR TITLE
[이해빈] Feat: 롤링페이퍼리스트 페이지, RecipientMenu 컴포넌트 반응형 디자인 추가

### DIFF
--- a/Rolling/package-lock.json
+++ b/Rolling/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "axios": "^1.6.2",
+        "dompurify": "^3.0.6",
         "emoji-picker-react": "^4.5.16",
         "prop-types": "^15.8.1",
         "react": "^18.2.0",
@@ -1659,6 +1660,11 @@
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.6.tgz",
+      "integrity": "sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w=="
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.608",

--- a/Rolling/package-lock.json
+++ b/Rolling/package-lock.json
@@ -23,6 +23,7 @@
         "react-slick": "^0.29.0",
         "slick-carousel": "^1.8.1",
         "styled-components": "^6.1.1",
+        "tailwind-scrollbar-hide": "^1.1.7",
         "yarn": "^1.22.21"
       },
       "devDependencies": {
@@ -4728,6 +4729,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/tailwind-scrollbar-hide": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/tailwind-scrollbar-hide/-/tailwind-scrollbar-hide-1.1.7.tgz",
+      "integrity": "sha512-X324n9OtpTmOMqEgDUEA/RgLrNfBF/jwJdctaPZDzB3mppxJk7TLIDmOreEDm1Bq4R9LSPu4Epf8VSdovNU+iA=="
     },
     "node_modules/tailwindcss": {
       "version": "3.3.6",

--- a/Rolling/package.json
+++ b/Rolling/package.json
@@ -25,6 +25,7 @@
     "react-slick": "^0.29.0",
     "slick-carousel": "^1.8.1",
     "styled-components": "^6.1.1",
+    "tailwind-scrollbar-hide": "^1.1.7",
     "yarn": "^1.22.21"
   },
   "devDependencies": {

--- a/Rolling/package.json
+++ b/Rolling/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "axios": "^1.6.2",
+    "dompurify": "^3.0.6",
     "emoji-picker-react": "^4.5.16",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",

--- a/Rolling/src/components/Common/Header.jsx
+++ b/Rolling/src/components/Common/Header.jsx
@@ -6,7 +6,7 @@ function Header() {
   const isVisiblePage = location.pathname === '/' || location.pathname === '/list';
 
   return (
-    <div className="flex items-center justify-between flex-shrink-0 py-2 px-4 xl:px-24 max-w-screen-xl mx-auto h-16 border-b-[1px] border-zinc-100">
+    <div className="hidden md:flex items-center justify-between flex-shrink-0 py-2 px-4 xl:px-24 max-w-screen-xl mx-auto h-16 border-b-[1px] border-zinc-100">
       <Link to={'/'}>
         <img src={logo} alt="로고" />
       </Link>

--- a/Rolling/src/components/Common/Header.jsx
+++ b/Rolling/src/components/Common/Header.jsx
@@ -6,7 +6,7 @@ function Header() {
   const isVisiblePage = location.pathname === '/' || location.pathname === '/list';
 
   return (
-    <div className="hidden md:flex items-center justify-between flex-shrink-0 py-2 px-4 xl:px-24 max-w-screen-xl mx-auto h-16 border-b-[1px] border-zinc-100">
+    <div className={`${isVisiblePage ? 'flex' : 'hidden'} md:flex items-center justify-between flex-shrink-0 py-2 px-4 xl:px-24 max-w-screen-xl mx-auto h-16 border-b-[1px] border-zinc-100`}>
       <Link to={'/'}>
         <img src={logo} alt="로고" />
       </Link>

--- a/Rolling/src/components/Common/ReactionBadge.jsx
+++ b/Rolling/src/components/Common/ReactionBadge.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 
 const ReactionBadge = ({ reaction }) => {
   return(
-    <div className="flex px-3 py-2 rounded-4xl gap-0.5 bg-black/[0.54]">
+    <div className="px-2 py-1.5 flex md:px-3 md:py-2 rounded-4xl gap-0.5 bg-black/[0.54]">
       <div className='text-sm md:text-base'>{reaction?.emoji || '👍'}</div>
       <p className='text-white text-sm md:text-base'>{reaction?.count || 0}</p>
     </div>

--- a/Rolling/src/components/Common/ReactionBadge.jsx
+++ b/Rolling/src/components/Common/ReactionBadge.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 const ReactionBadge = ({ reaction }) => {
   return(
     <div className="flex px-3 py-2 rounded-4xl gap-0.5 bg-black/[0.54]">
-      <div>{reaction?.emoji || '👍'}</div>
-      <p className='text-white'>{reaction?.count || 0}</p>
+      <div className='text-sm md:text-base'>{reaction?.emoji || '👍'}</div>
+      <p className='text-white text-sm md:text-base'>{reaction?.count || 0}</p>
     </div>
   )
 };

--- a/Rolling/src/components/MessagePage/MessageCard.jsx
+++ b/Rolling/src/components/MessagePage/MessageCard.jsx
@@ -5,6 +5,7 @@ import formatDate from '../../utils/formatDate';
 import axios from 'axios';
 import { useState } from 'react';
 import ConfirmModal from '../Common/ConfirmModal';
+import DOMPurify from 'dompurify';
 
 function MessageCard({ message, handleClickMessage, showTrashIcon = false }) {
   const [showConfirmModal, setShowConfirmModal] = useState(false);
@@ -67,9 +68,10 @@ function MessageCard({ message, handleClickMessage, showTrashIcon = false }) {
           )}
         </div>
         <div className="h-28 line-clamp-4 cursor-pointer" onClick={getMessageId}>
-          <p className={`text-[#4A4A4A] text-lg leading-7 ${MESSAGE_FONT[message.font]}`}>
-            {message.content}
-          </p>
+          <p
+            className={`text-[#4A4A4A] text-lg leading-7 ${MESSAGE_FONT[message.font]}`}
+            dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(message.content) }}
+          />
         </div>
         <p className="bottom-[30px] text-[#999] text-xs">{formatDate(message.createdAt)}</p>
       </div>

--- a/Rolling/src/components/MessagePage/MessageCardContents.jsx
+++ b/Rolling/src/components/MessagePage/MessageCardContents.jsx
@@ -63,9 +63,11 @@ function MessageCardContents({ recipient, messages, postId, loading }) {
         <div className="lg:grid lg:grid-cols-[repeat(3,minmax(0,24rem))] md:grid md:grid-cols-[repeat(2,minmax(0,24rem))] grid grid-cols-[repeat(1,minmax(0,24rem))] justify-center gap-4">
           {!location.pathname.includes('edit') && (
             <div className="flex justify-center items-center max-w-sm h-[280px] shadow-[0px_2px_12px_0px_rgba(0,0,0,0.08)] rounded-2xl bg-white">
-              <button className="flex items-start gap-2.5 p-4">
-                <BsFillPlusCircleFill className="w-14 h-14 fill-gray-500 grid-cols" />
-              </button>
+              <Link to={`/post/${postId}/message`}>
+                <button className="flex items-start gap-2.5 p-4">
+                  <BsFillPlusCircleFill className="w-14 h-14 fill-gray-500 grid-cols" />
+                </button>
+              </Link>
             </div>
           )}
 

--- a/Rolling/src/components/MessagePage/MessageCardModal.jsx
+++ b/Rolling/src/components/MessagePage/MessageCardModal.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import { MESSAGE_FONT, RELATIONSHIP_TAG_COLOR } from '../../constants/constants';
 import formatDate from '../../utils/formatDate';
+import DOMPurify from 'dompurify';
 
 function MessageCardModal({ message, handleCloseModal }) {
   return (
@@ -30,7 +31,10 @@ function MessageCardModal({ message, handleCloseModal }) {
         </div>
 
         <div className="mt-3 h-60 overflow-y-auto">
-          <span className="text-lg text-[#5A5A5A]">{message.content}</span>
+          <span
+            className={`text-[#4A4A4A] text-lg leading-7 ${MESSAGE_FONT[message.font]}`}
+            dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(message.content) }}
+          />
         </div>
 
         <div className="mt-5 text-center">

--- a/Rolling/src/components/PostMessagePage/PostMessagePage.jsx
+++ b/Rolling/src/components/PostMessagePage/PostMessagePage.jsx
@@ -27,7 +27,7 @@ function PostMessagePage() {
     }
 
     try {
-      const response = await axios.post(
+      await axios.post(
         `https://rolling-api.vercel.app/2-5/recipients/${id}/messages/`,
         JSON.stringify(formData),
         {
@@ -36,8 +36,7 @@ function PostMessagePage() {
           },
         }
       );
-      const messageId = response.data.id;
-      navigate(`/post/${messageId}`);
+      navigate(`/post/${id}`);
     } catch (error) {
       throw new Error('데이터를 보내는데 실패했습니다.');
     }

--- a/Rolling/src/components/RecipientMenu/ReactionContainer.jsx
+++ b/Rolling/src/components/RecipientMenu/ReactionContainer.jsx
@@ -73,16 +73,16 @@ const ReactionContainer = ({ recipientId }) => {
   };
 
   return(
-    <div className="flex gap-2 relative">
+    <div className="flex md:gap-2 relative">
       <div className="flex">
         <div className="flex items-center justify-center gap-2">
           {reactions?.slice(0,3).map((reaction) => <ReactionBadge key={reaction.emoji} reaction={reaction} />)}
         </div>
         <button className="py-1.5 px-1.5" onClick={handleClickAdditionalReaction}><IoIosArrowDown className="w-6 h-6"/></button>
       </div>
-      <button className="flex justify-center items-center py-1.5 px-4 gap-1 border rounded-md border-gray-300" onClick={handleClickAddButton}>
+      <button className="flex justify-center items-center py-1.5 px-2 md:px-4 gap-1 border rounded-md border-gray-300" onClick={handleClickAddButton}>
         <LuSmilePlus className="w-6 h-6"/>
-        <p className="text-base">추가</p>
+        <p className="hidden text-base md:flex">추가</p>
       </button>
       {additionalReactionOpen && <AdditionalReactionContainer recipientId={recipientId}/>}
       {emojiPickerOpen && <div className="absolute top-11 left-4 z-10"><EmojiPicker onEmojiClick={(value) => handleAddReaction(value.emoji)} width={307} height={393}/></div>}

--- a/Rolling/src/components/RecipientMenu/RecipientMenu.jsx
+++ b/Rolling/src/components/RecipientMenu/RecipientMenu.jsx
@@ -13,19 +13,25 @@ const RecipientMenu = ({ recipient }) => {
   };
 
   return(
-    <nav className="w-full relative py-[13px]">
-      <div className="mx-auto flex gap-64 w-fit relative">
-        <div className="recipent font-bold text-3xl font-pre">{`To. ${recipient?.name}`}</div>
-        <div className="flex items-center gap-7 justify-center">
-          <div className="flex gap-2.5">
+    <nav className="max-w-full relative py-[13px]">
+      <div className="flex min-w-[360px] md:min-w-[768px] md:max-w-[1248px] relative flex-col md:flex-row md:justify-between mx-auto md:px-6 xl:px-24">
+        <div className="px-5 py-3 text-lg font-bold flex justify-center md:block md:px-0 md:py-0 md:text-3xl font-[pretendard]">
+          <p className="mx-0 my-0 px-0 py-0 min-w-[320px] md:min-w-[227px]">
+            {`To. ${recipient?.name}`}
+          </p>
+        </div>
+        <div className="flex items-center md:gap-7 justify-center py-2 px-5 md:px-0 md:py-0 md:justify-center">
+          <div className="hidden lg:flex gap-2.5">
             <Avatar recentMessages={recipient?.recentMessages} messageCount={recipient?.messageCount}/>
             <div className="text-lg text-gray-900 font-pre">{`${recipient?.messageCount}명이 작성했어요!`}</div>
           </div>
-          <div className="w-px h-7 bg-gray-200" />
-          <ReactionContainer topReactions={recipient?.topReactions} recipientId={recipient?.id}/>
-          <div className="w-px h-7 bg-gray-200" />
-          <button className="px-4 py-2 border border-gray-300 rounded-md" onClick={handleClickShareButton}><IoShareOutline className="w-6 h-6"/></button>
-          {shareMenuOpen && <ShareMenu />}
+          <div className="hidden lg:flex w-px h-7 bg-gray-200" />
+          <div className="flex gap-[13px] justify-center items-center">
+            <ReactionContainer topReactions={recipient?.topReactions} recipientId={recipient?.id}/>
+            <div className="w-px h-7 bg-gray-200" />
+            <button className="px-2 py-1.5 border border-gray-300 rounded-md md:px-4" onClick={handleClickShareButton}><IoShareOutline className="w-6 h-6"/></button>
+            {shareMenuOpen && <ShareMenu />}
+          </div>
         </div>
       </div>
     </nav>

--- a/Rolling/src/components/RollingPaperListPage/RollingPaperCard.jsx
+++ b/Rolling/src/components/RollingPaperListPage/RollingPaperCard.jsx
@@ -20,10 +20,10 @@ const RollingPaperCard = ({ rollingPaper }) => {
 
   return(
     <Link to={`/post/${rollingPaper.id}`}>
-      <div  className={`w-[275px] h-[260px] rounded-2xl border-solid border-2 pt-[30px] pb-5 px-6 shadow-md ${BACKGROUND_COLOR[rollingPaper.backgroundColor]} 
+      <div  className={`w-[216px] h-[232px] md:w-[275px] md:h-[260px] rounded-2xl border-solid border-2 pt-[30px] pb-5 px-6 shadow-md ${BACKGROUND_COLOR[rollingPaper.backgroundColor]} 
         ${rollingPaper?.backgroundImageURL ? 'bg-cover text-white object-cover' : 'bg-no-repeat bg-right-bottom'}`} style={{ backgroundImage: `url(${background})` }}>
-        <div className="flex flex-col gap-3 mb-7">
-          <div className="font-bold text-pretendard text-2xl leading-10 tracking-tight">
+        <div className="flex flex-col gap-3 mb-[33px]">
+          <div className="text-lg font-bold text-pretendard leading-7 md:text-2xl md:leading-9 tracking-tight">
             To. {rollingPaper.name}
           </div>
           <Avatar recentMessages={rollingPaper.recentMessages} messageCount={rollingPaper.messageCount}/>
@@ -34,8 +34,11 @@ const RollingPaperCard = ({ rollingPaper }) => {
             명이 작성했어요
           </div>
         </div>
-        <div className="flex items-center  border-t border-black/[0.12] gap-3 pt-4">
-          {rollingPaper.topReactions.map((reaction) => <ReactionBadge key={reaction.id} reaction={reaction}/>)}
+        <div className='flex flex-col gap-4 justify-center items-center'>
+          <div className='w-[162px] md:w-[227px] h-px bg-black/[0.12]' />
+          <div className="flex items-center gap-1 md:gap-3">
+            {rollingPaper.topReactions.map((reaction) => <ReactionBadge key={reaction.id} reaction={reaction}/>)}
+          </div>
         </div>
       </div>
     </Link>

--- a/Rolling/src/components/RollingPaperListPage/RollingPaperCard.jsx
+++ b/Rolling/src/components/RollingPaperListPage/RollingPaperCard.jsx
@@ -21,7 +21,7 @@ const RollingPaperCard = ({ rollingPaper }) => {
   return(
     <Link to={`/post/${rollingPaper.id}`}>
       <div  className={`w-[275px] h-[260px] rounded-2xl border-solid border-2 pt-[30px] pb-5 px-6 shadow-md ${BACKGROUND_COLOR[rollingPaper.backgroundColor]} 
-        ${rollingPaper?.backgroundImageURL ? 'bg-cover text-white' : 'bg-no-repeat bg-right-bottom'}`} style={{ backgroundImage: `url(${background})` }}>
+        ${rollingPaper?.backgroundImageURL ? 'bg-cover text-white object-cover' : 'bg-no-repeat bg-right-bottom'}`} style={{ backgroundImage: `url(${background})` }}>
         <div className="flex flex-col gap-3 mb-7">
           <div className="font-bold text-pretendard text-2xl leading-10 tracking-tight">
             To. {rollingPaper.name}

--- a/Rolling/src/components/RollingPaperListPage/RollingPaperList.jsx
+++ b/Rolling/src/components/RollingPaperListPage/RollingPaperList.jsx
@@ -9,8 +9,8 @@ const RollingPaperList = ({ title, rollingPaperList }) => {
   const [activeItemIndex, setActiveItemIndex] = useState(0);
   
   return(
-    <div className="w-full">
-      <div className=" max-w-[1160px] mx-auto flex flex-col gap-4 sm:w-fit">
+    <div className="w-full overflow-scroll scrollbar-hide">
+      <div className="min-w-[904px] max-w-[910px] md:max-w-[1160px] mx-auto flex flex-col gap-4 sm:w-fit">
         <div className="font-pre text-2xl font-bold tracking-[-0.24px]">{title}</div>
         <ItemsCarousel
           requestToChangeActive={(value) => setActiveItemIndex(value)}

--- a/Rolling/src/components/RollingPaperListPage/RollingPaperListPage.jsx
+++ b/Rolling/src/components/RollingPaperListPage/RollingPaperListPage.jsx
@@ -12,7 +12,7 @@ const RollingPaperListPage = () => {
 
   return (
     <Suspense fallback={<RollingPaperListSkeleton />}>
-      <div className='pt-[50px] flex flex-col gap-[50px]'>
+      <div className='pt-[40px] pl-5 md:pt-[50px] flex flex-col gap-[50px]'>
         <RollingPaperList title={'인기 롤링 페이퍼 10 🔥'} rollingPaperList={likeSortRollingPaper}/>
         <RollingPaperList title={'최근에 만든 롤링 페이퍼 10 ⭐️️'} rollingPaperList={createdSortRollingPaper}/>
         <Button to="/post">나도 만들어보기</Button>

--- a/Rolling/tailwind.config.js
+++ b/Rolling/tailwind.config.js
@@ -20,5 +20,5 @@ export default {
       extend: {},
     },
   },
-  plugins: [require("daisyui")],
+  plugins: [require("daisyui"), require("tailwind-scrollbar-hide")],
 };


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 요구 사항
- [x]  Tablet에서 롤링 페이퍼 카드 목록 영역이 화면의 너비를 넘어갈 경우 터치로 좌우 스크롤 가능합니다.
- [x]  Tablet에서  상단 네비게이션은 좌우 여백은 24px로 고정하고 '로고'와 '롤링 페이퍼 만들기' 버튼의 간격이 줄어들거나 커집니다.
- [x]  Mobile에서 롤링 페이퍼 카드 목록 영역이 화면의 너비를 넘어갈 경우 터치로 좌우 스크롤 가능합니다.

### 변경 사항
- 롤링페이퍼리스트 페이지, RecipientMenu 컴포넌트 반응형 디자인 추가

### 테스트 결과
