### PR TITLE
[손오름] Feat: 삭제할 메세지 개별 선택 후 저장하기 버튼 누르면 일괄 삭제 되도록 기능 구현

### DIFF
--- a/Rolling/src/components/Common/ConfirmModal.jsx
+++ b/Rolling/src/components/Common/ConfirmModal.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 function ConfirmModal({ title, onConfirm, onCancel, showCancelButton = true }) {
   return (
     <>
-      <div className="flex flex-col justify-end gap-9 p-8 bg-white fixed -translate-x-2/4 -translate-y-2/4 left-2/4 w-96 h-56 rounded-3xl top-2/4 z-10">
+      <div className="flex flex-col justify-end gap-9 p-8 bg-white fixed -translate-x-2/4 -translate-y-2/4 left-2/4 w-96 h-56 rounded-3xl top-2/4 z-20">
         <p className="text-center text-xl font-bold">{title}</p>
 
         <div className="flex justify-center gap-5">
@@ -23,7 +23,7 @@ function ConfirmModal({ title, onConfirm, onCancel, showCancelButton = true }) {
           )}
         </div>
       </div>
-      <div onClick={onCancel} className="fixed bg-[black] opacity-[60%] inset-0"></div>
+      <div onClick={onCancel} className="fixed bg-[black] opacity-[60%] inset-0 z-10"></div>
     </>
   );
 }

--- a/Rolling/src/components/MessagePage/MessageCard.jsx
+++ b/Rolling/src/components/MessagePage/MessageCard.jsx
@@ -3,35 +3,19 @@ import { MESSAGE_FONT, RELATIONSHIP_TAG_COLOR } from '../../constants/constants'
 import { LiaTrashAltSolid } from 'react-icons/lia';
 import { IoReload } from 'react-icons/io5';
 import formatDate from '../../utils/formatDate';
-import axios from 'axios';
 import { useState } from 'react';
-import ConfirmModal from '../Common/ConfirmModal';
 import DOMPurify from 'dompurify';
 
-function MessageCard({ message, handleClickMessage, handleDeleteMessage, showTrashIcon = false }) {
-  const [showConfirmModal, setShowConfirmModal] = useState(false);
-  const [showCompleteModal, setShowCompleteModal] = useState(false);
+function MessageCard({
+  message,
+  clickedMessageModal,
+  getClickedMessageIds,
+  showTrashIcon = false,
+}) {
   const [markedForDeletion, setMarkedForDeletion] = useState(false);
 
-  const getMessageId = () => {
-    handleClickMessage(message.id);
-  };
-
-  const handleDismissModal = () => {
-    setShowConfirmModal(false);
-    setShowCompleteModal(false);
-  };
-
-  const handleMessageRemove = () => {
-    setShowConfirmModal(false);
-    setMarkedForDeletion(true);
-    // try {
-    //   await axios.delete(`https://rolling-api.vercel.app/2-5/messages/${message.id}/`);
-    //   setShowConfirmModal(false);
-    //   setShowCompleteModal(true);
-    // } catch (error) {
-    //   alert(error);
-    // }
+  const getClickedMessageId = () => {
+    clickedMessageModal(message.id);
   };
 
   return (
@@ -65,8 +49,8 @@ function MessageCard({ message, handleClickMessage, handleDeleteMessage, showTra
           {showTrashIcon && !markedForDeletion && (
             <button
               onClick={() => {
-                handleDeleteMessage(message.id);
-                setShowConfirmModal(true);
+                getClickedMessageIds(message.id);
+                setMarkedForDeletion(true);
               }}
               className="border border-[#CCC] p-2 rounded-md "
             >
@@ -76,6 +60,7 @@ function MessageCard({ message, handleClickMessage, handleDeleteMessage, showTra
           {markedForDeletion && (
             <button
               onClick={() => {
+                getClickedMessageIds(message.id);
                 setMarkedForDeletion(false);
               }}
               className="border border-[#CCC] p-2 rounded-md "
@@ -84,7 +69,7 @@ function MessageCard({ message, handleClickMessage, handleDeleteMessage, showTra
             </button>
           )}
         </div>
-        <div className="h-28 line-clamp-4 cursor-pointer" onClick={getMessageId}>
+        <div className="h-28 line-clamp-4 cursor-pointer" onClick={getClickedMessageId}>
           <p
             className={`text-[#4A4A4A] text-lg leading-7 ${MESSAGE_FONT[message.font]}`}
             dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(message.content) }}
@@ -92,37 +77,14 @@ function MessageCard({ message, handleClickMessage, handleDeleteMessage, showTra
         </div>
         <p className="bottom-[30px] text-[#999] text-xs">{formatDate(message.createdAt)}</p>
       </div>
-
-      {showConfirmModal && (
-        <ConfirmModal
-          title="해당 메세지를 삭제하시겠습니까?"
-          onConfirm={handleMessageRemove}
-          onCancel={handleDismissModal}
-        />
-      )}
-
-      {showCompleteModal && (
-        <ConfirmModal
-          title="삭제가 완료되었습니다."
-          onConfirm={() => {
-            setShowCompleteModal(false);
-            window.location.reload();
-          }}
-          onCancel={() => {
-            setShowCompleteModal(false);
-            window.location.reload();
-          }}
-          showCancelButton={false}
-        />
-      )}
     </>
   );
 }
 
 MessageCard.propTypes = {
   message: PropTypes.object,
-  handleClickMessage: PropTypes.func,
-  handleDeleteMessage: PropTypes.func,
+  clickedMessageModal: PropTypes.func,
+  getClickedMessageIds: PropTypes.func,
   showTrashIcon: PropTypes.bool,
 };
 

--- a/Rolling/src/components/MessagePage/MessageCard.jsx
+++ b/Rolling/src/components/MessagePage/MessageCard.jsx
@@ -1,15 +1,17 @@
 import PropTypes from 'prop-types';
 import { MESSAGE_FONT, RELATIONSHIP_TAG_COLOR } from '../../constants/constants';
 import { LiaTrashAltSolid } from 'react-icons/lia';
+import { IoReload } from 'react-icons/io5';
 import formatDate from '../../utils/formatDate';
 import axios from 'axios';
 import { useState } from 'react';
 import ConfirmModal from '../Common/ConfirmModal';
 import DOMPurify from 'dompurify';
 
-function MessageCard({ message, handleClickMessage, showTrashIcon = false }) {
+function MessageCard({ message, handleClickMessage, handleDeleteMessage, showTrashIcon = false }) {
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [showCompleteModal, setShowCompleteModal] = useState(false);
+  const [markedForDeletion, setMarkedForDeletion] = useState(false);
 
   const getMessageId = () => {
     handleClickMessage(message.id);
@@ -20,21 +22,25 @@ function MessageCard({ message, handleClickMessage, showTrashIcon = false }) {
     setShowCompleteModal(false);
   };
 
-  const handleMessageRemove = async () => {
-    try {
-      await axios.delete(`https://rolling-api.vercel.app/2-5/messages/${message.id}/`);
-      setShowConfirmModal(false);
-      setShowCompleteModal(true);
-    } catch (error) {
-      alert(error);
-    }
+  const handleMessageRemove = () => {
+    setShowConfirmModal(false);
+    setMarkedForDeletion(true);
+    // try {
+    //   await axios.delete(`https://rolling-api.vercel.app/2-5/messages/${message.id}/`);
+    //   setShowConfirmModal(false);
+    //   setShowCompleteModal(true);
+    // } catch (error) {
+    //   alert(error);
+    // }
   };
 
   return (
     <>
       <div
-        className="flex flex-col gap-5 max-w-sm h-[280px] px-6 py-7 shadow-[0px_2px_12px_0px_rgba(0,0,0,0.08)] rounded-2xl bg-white"
-        key={message.id}
+        className={`flex flex-col gap-5 max-w-sm h-[280px] px-6 py-7 shadow-[0px_2px_12px_0px_rgba(0,0,0,0.08)] rounded-2xl bg-white ${
+          markedForDeletion ? 'opacity-70' : 0
+        }
+        key={message.id}`}
       >
         <div className="flex justify-between items-center border-b border-b-[#eee]">
           <div className="flex">
@@ -56,14 +62,25 @@ function MessageCard({ message, handleClickMessage, showTrashIcon = false }) {
               </span>
             </div>
           </div>
-          {showTrashIcon && (
+          {showTrashIcon && !markedForDeletion && (
             <button
               onClick={() => {
+                handleDeleteMessage(message.id);
                 setShowConfirmModal(true);
               }}
               className="border border-[#CCC] p-2 rounded-md "
             >
-              <LiaTrashAltSolid />
+              {markedForDeletion ? <IoReload /> : <LiaTrashAltSolid />}
+            </button>
+          )}
+          {markedForDeletion && (
+            <button
+              onClick={() => {
+                setMarkedForDeletion(false);
+              }}
+              className="border border-[#CCC] p-2 rounded-md "
+            >
+              <IoReload />
             </button>
           )}
         </div>
@@ -105,6 +122,7 @@ function MessageCard({ message, handleClickMessage, showTrashIcon = false }) {
 MessageCard.propTypes = {
   message: PropTypes.object,
   handleClickMessage: PropTypes.func,
+  handleDeleteMessage: PropTypes.func,
   showTrashIcon: PropTypes.bool,
 };
 

--- a/Rolling/src/components/MessagePage/MessageCardContents.jsx
+++ b/Rolling/src/components/MessagePage/MessageCardContents.jsx
@@ -1,28 +1,39 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
+import axios from 'axios';
 import PropTypes from 'prop-types';
 import MessageCard from './MessageCard';
 import MessageCardModal from './MessageCardModal.jsx';
 import { BsFillPlusCircleFill } from 'react-icons/bs';
 import { BACKGROUND_COLOR } from '../../constants/constants.js';
-import MessageLoading from '../MessagePage/MessageLoading';
 import { Link, useLocation } from 'react-router-dom';
-import PaperRemoveModal from './PaperRemoveModal.jsx';
+import MessageLoading from '../MessagePage/MessageLoading';
+import MessagePageRemove from './MessagePageRemove.jsx';
+import ConfirmModal from '../Common/ConfirmModal';
 
 function MessageCardContents({ recipient, messages, postId, loading }) {
   const [clickedMessage, setClickedMessage] = useState([]);
   const [openMessageModal, setOpenMessageModal] = useState(false);
   const [openRemoveModal, setOpenRemoveModal] = useState(false);
   const [clickedMessageIds, setClickedMessageIds] = useState([]);
+  const [showConfirmModal, setShowConfirmModal] = useState(false);
+  const [showCompleteModal, setShowCompleteModal] = useState(false);
 
   const location = useLocation();
 
-  const handleClickMessage = (id) => {
+  const clickedMessageModal = (id) => {
     const message = messages.find((message) => message.id === id);
     setClickedMessage(message);
-    handleOpenModal();
+
+    setOpenMessageModal(true);
+    document.body.style.overflow = 'hidden';
   };
 
-  const handleDeleteMessage = (clickedMessageId) => {
+  const handleCloseModal = () => {
+    setOpenMessageModal(false);
+    document.body.style = '';
+  };
+
+  const getClickedMessageIds = (clickedMessageId) => {
     setClickedMessageIds((prevSet) => {
       const updatedSet = new Set(prevSet);
       if (updatedSet.has(clickedMessageId)) {
@@ -36,21 +47,27 @@ function MessageCardContents({ recipient, messages, postId, loading }) {
     });
   };
 
-  useEffect(() => {
-    console.log(clickedMessageIds);
-  }, [clickedMessageIds]);
-  const handleOpenModal = () => {
-    setOpenMessageModal(true);
-    document.body.style.overflow = 'hidden';
+  const handleRemoveMessage = async () => {
+    try {
+      clickedMessageIds.map(async (messageId) => {
+        await axios.delete(`https://rolling-api.vercel.app/2-5/messages/${messageId}/`);
+      });
+
+      setClickedMessageIds([]);
+      setShowConfirmModal(false);
+      setShowCompleteModal(true);
+    } catch (error) {
+      alert(error);
+    }
   };
 
-  const handleCloseModal = () => {
-    setOpenMessageModal(false);
-    document.body.style = '';
-  };
-
-  const handleRemovePaper = () => {
+  const removeMessagePape = () => {
     setOpenRemoveModal(true);
+  };
+
+  const handleDismissModal = () => {
+    setShowConfirmModal(false);
+    setShowCompleteModal(false);
   };
 
   return (
@@ -69,20 +86,46 @@ function MessageCardContents({ recipient, messages, postId, loading }) {
         ) : (
           <div className="flex gap-3">
             <button
-              onClick={handleRemovePaper}
+              onClick={removeMessagePape}
               className="hover:bg-orange-700 w-44 px-6 py-3.5 bg-orange-600 rounded-xl justify-center items-center gap-2.5 inline-flex text-center text-white text-lg font-bold font-['Pretendard'] leading-7"
             >
               페이지 삭제하기
             </button>
 
-            <button className="sm:w-full sm:fixed sm:left-0 sm:bottom-6 hover:bg-purple-700 lg:static lg:w-32 px-6 py-3.5 bg-purple-600 rounded-xl justify-center items-center gap-2.5 inline-flex text-center text-white text-lg font-bold font-['Pretendard'] leading-7">
+            <button
+              onClick={() => setShowConfirmModal(true)}
+              className="sm:w-full sm:fixed sm:left-0 sm:bottom-6 hover:bg-purple-700 lg:static lg:w-32 px-6 py-3.5 bg-purple-600 rounded-xl justify-center items-center gap-2.5 inline-flex text-center text-white text-lg font-bold font-['Pretendard'] leading-7"
+            >
               저장하기
             </button>
           </div>
         )}
 
         {openRemoveModal && (
-          <PaperRemoveModal recipient={recipient} setOpenRemoveModal={setOpenRemoveModal} />
+          <MessagePageRemove recipient={recipient} setOpenRemoveModal={setOpenRemoveModal} />
+        )}
+
+        {showConfirmModal && (
+          <ConfirmModal
+            title="선택한 메세지들을 삭제하고 저장하시겠습니까?"
+            onConfirm={handleRemoveMessage}
+            onCancel={handleDismissModal}
+          />
+        )}
+
+        {showCompleteModal && (
+          <ConfirmModal
+            title="삭제가 완료되었습니다."
+            onConfirm={() => {
+              setShowCompleteModal(false);
+              window.location.reload();
+            }}
+            onCancel={() => {
+              setShowCompleteModal(false);
+              window.location.reload();
+            }}
+            showCancelButton={false}
+          />
         )}
 
         <div className="lg:grid lg:grid-cols-[repeat(3,minmax(0,24rem))] md:grid md:grid-cols-[repeat(2,minmax(0,24rem))] grid grid-cols-[repeat(1,minmax(0,24rem))] justify-center gap-4">
@@ -101,15 +144,15 @@ function MessageCardContents({ recipient, messages, postId, loading }) {
                 <MessageCard
                   key={message.id}
                   message={message}
-                  handleClickMessage={handleClickMessage}
+                  clickedMessageModal={clickedMessageModal}
                 />
               ))
             : messages?.map((message) => (
                 <MessageCard
                   key={message.id}
                   message={message}
-                  handleClickMessage={handleClickMessage}
-                  handleDeleteMessage={handleDeleteMessage}
+                  clickedMessageModal={clickedMessageModal}
+                  getClickedMessageIds={getClickedMessageIds}
                   showTrashIcon={true}
                 />
               ))}

--- a/Rolling/src/components/MessagePage/MessageCardContents.jsx
+++ b/Rolling/src/components/MessagePage/MessageCardContents.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import MessageCard from './MessageCard';
 import MessageCardModal from './MessageCardModal.jsx';
@@ -12,6 +12,8 @@ function MessageCardContents({ recipient, messages, postId, loading }) {
   const [clickedMessage, setClickedMessage] = useState([]);
   const [openMessageModal, setOpenMessageModal] = useState(false);
   const [openRemoveModal, setOpenRemoveModal] = useState(false);
+  const [clickedMessageIds, setClickedMessageIds] = useState([]);
+
   const location = useLocation();
 
   const handleClickMessage = (id) => {
@@ -20,6 +22,23 @@ function MessageCardContents({ recipient, messages, postId, loading }) {
     handleOpenModal();
   };
 
+  const handleDeleteMessage = (clickedMessageId) => {
+    setClickedMessageIds((prevSet) => {
+      const updatedSet = new Set(prevSet);
+      if (updatedSet.has(clickedMessageId)) {
+        updatedSet.delete(clickedMessageId);
+      } else {
+        updatedSet.add(clickedMessageId);
+      }
+
+      const updatedArray = Array.from(updatedSet);
+      return updatedArray;
+    });
+  };
+
+  useEffect(() => {
+    console.log(clickedMessageIds);
+  }, [clickedMessageIds]);
   const handleOpenModal = () => {
     setOpenMessageModal(true);
     document.body.style.overflow = 'hidden';
@@ -48,12 +67,18 @@ function MessageCardContents({ recipient, messages, postId, loading }) {
             </button>
           </Link>
         ) : (
-          <button
-            onClick={handleRemovePaper}
-            className="sm:w-full sm:fixed sm:left-0 sm:bottom-6 hover:bg-purple-700 lg:static lg:w-32 px-6 py-3.5 bg-purple-600 rounded-xl justify-center items-center gap-2.5 inline-flex text-center text-white text-lg font-bold font-['Pretendard'] leading-7"
-          >
-            삭제하기
-          </button>
+          <div className="flex gap-3">
+            <button
+              onClick={handleRemovePaper}
+              className="hover:bg-orange-700 w-44 px-6 py-3.5 bg-orange-600 rounded-xl justify-center items-center gap-2.5 inline-flex text-center text-white text-lg font-bold font-['Pretendard'] leading-7"
+            >
+              페이지 삭제하기
+            </button>
+
+            <button className="sm:w-full sm:fixed sm:left-0 sm:bottom-6 hover:bg-purple-700 lg:static lg:w-32 px-6 py-3.5 bg-purple-600 rounded-xl justify-center items-center gap-2.5 inline-flex text-center text-white text-lg font-bold font-['Pretendard'] leading-7">
+              저장하기
+            </button>
+          </div>
         )}
 
         {openRemoveModal && (
@@ -84,6 +109,7 @@ function MessageCardContents({ recipient, messages, postId, loading }) {
                   key={message.id}
                   message={message}
                   handleClickMessage={handleClickMessage}
+                  handleDeleteMessage={handleDeleteMessage}
                   showTrashIcon={true}
                 />
               ))}

--- a/Rolling/src/components/MessagePage/MessageCardContents.jsx
+++ b/Rolling/src/components/MessagePage/MessageCardContents.jsx
@@ -6,11 +6,10 @@ import MessageCardModal from './MessageCardModal.jsx';
 import { BsFillPlusCircleFill } from 'react-icons/bs';
 import { BACKGROUND_COLOR } from '../../constants/constants.js';
 import { Link, useLocation } from 'react-router-dom';
-import MessageLoading from '../MessagePage/MessageLoading';
 import MessagePageRemove from './MessagePageRemove.jsx';
 import ConfirmModal from '../Common/ConfirmModal';
 
-function MessageCardContents({ recipient, messages, postId, loading }) {
+function MessageCardContents({ recipient, messages, postId }) {
   const [clickedMessage, setClickedMessage] = useState([]);
   const [openMessageModal, setOpenMessageModal] = useState(false);
   const [openRemoveModal, setOpenRemoveModal] = useState(false);
@@ -162,8 +161,6 @@ function MessageCardContents({ recipient, messages, postId, loading }) {
           )}
         </div>
       </div>
-
-      {loading && <MessageLoading />}
     </>
   );
 }

--- a/Rolling/src/components/MessagePage/MessagePage.jsx
+++ b/Rolling/src/components/MessagePage/MessagePage.jsx
@@ -10,7 +10,6 @@ function MessagePage() {
   const [messages, setMessages] = useState([]);
   const [offset, setOffset] = useState(0);
   const [hasNext, setHasNext] = useState(null);
-  const [loading, setLoading] = useState(false);
 
   const { id } = useParams();
   const observerRef = useRef(null);
@@ -29,7 +28,6 @@ function MessagePage() {
   useEffect(() => {
     const getRollingMessages = async () => {
       try {
-        setLoading(true);
         const response = await axios.get(
           `https://rolling-api.vercel.app/2-5/recipients/${id}/messages/?limit=${LIMIT}&offset=${offset}`
         );
@@ -43,8 +41,6 @@ function MessagePage() {
         setHasNext(next);
       } catch (error) {
         alert(error);
-      } finally {
-        setLoading(false);
       }
     };
     getRollingMessages();
@@ -91,12 +87,7 @@ function MessagePage() {
       <Suspense fallback={<div className="skeleton w-11/12 h-[68px] mx-auto"></div>}>
         <RecipientMenu recipient={recipient} />
       </Suspense>
-      <MessageCardContents
-        recipient={recipient}
-        messages={messages}
-        postId={id}
-        loading={loading}
-      />
+      <MessageCardContents recipient={recipient} messages={messages} postId={id} />
       <div id="observer-element" ref={observerRef}></div>
     </>
   );

--- a/Rolling/src/components/MessagePage/MessagePageRemove.jsx
+++ b/Rolling/src/components/MessagePage/MessagePageRemove.jsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import ConfirmModal from '../Common/ConfirmModal';
 
-function PaperRemoveModal({ recipient, setOpenRemoveModal }) {
+function MessagePageRemove({ recipient, setOpenRemoveModal }) {
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const navigate = useNavigate();
 
@@ -52,9 +52,9 @@ function PaperRemoveModal({ recipient, setOpenRemoveModal }) {
   );
 }
 
-PaperRemoveModal.propTypes = {
+MessagePageRemove.propTypes = {
   recipient: PropTypes.object,
   setOpenRemoveModal: PropTypes.func,
 };
 
-export default PaperRemoveModal;
+export default MessagePageRemove;

--- a/Rolling/src/hooks/hooks.js
+++ b/Rolling/src/hooks/hooks.js
@@ -1,5 +1,5 @@
-import axios from "axios";
-import { useCallback, useEffect, useState } from "react";
+import axios from 'axios';
+import { useCallback, useEffect, useState } from 'react';
 
 const LIMIT = 10;
 const RECIPIENT_API = `https://rolling-api.vercel.app/2-5/recipients/?limit=${LIMIT}&offset=0`;
@@ -9,13 +9,13 @@ export const useRollingPaperList = (sort = '') => {
   const [url, setUrl] = useState(`${RECIPIENT_API}&sort=${sort}`);
   const [error, setError] = useState();
 
-  const getRollingPaperList = useCallback(async() => {
-    try{
+  const getRollingPaperList = useCallback(async () => {
+    try {
       const response = await axios.get(url);
       const { next, results } = await response.data;
-      if(next) setUrl(next);
+      if (next) setUrl(next);
       setRollingPaperList((prev) => [...prev, ...results]);
-    } catch(error) {
+    } catch (error) {
       alert(error);
       setError(error);
     }
@@ -23,7 +23,7 @@ export const useRollingPaperList = (sort = '') => {
 
   useEffect(() => {
     getRollingPaperList();
-  }, [getRollingPaperList])
+  }, [getRollingPaperList]);
 
   return [rollingPaperList, error];
 };


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 요구 사항
- [x]  [생성된 롤링페이퍼 수정 페이지] '편집하기' 버튼을 클릭하면 편집모드가 되고 '+' 버튼이 있는 카드는 사라집니다, '쓰레기통' 모양 버튼을 클릭하면 해당하는 카드는 사라집니다, '저장하기' 버튼을 클릭하면 수정된 내용으로 저장합니다,

### 변경 사항
- 편집 모드에서 저장하기 버튼 추가했습니다.

### 테스트 결과
https://github.com/CodeitFE2-team5/Rolling/assets/105328855/0b6f56df-160d-46a6-8e34-69a6d494d2f1

