### PR TITLE
[손오름] Feat: 편집모드에서 삭제할 카드를 하나도 선택하지 않았을 시 저장하기 버튼 비활성화 되게 구현

### DIFF
--- a/Rolling/src/components/MessagePage/MessageCardContents.jsx
+++ b/Rolling/src/components/MessagePage/MessageCardContents.jsx
@@ -93,7 +93,10 @@ function MessageCardContents({ recipient, messages, postId }) {
 
             <button
               onClick={() => setShowConfirmModal(true)}
-              className="sm:w-full sm:fixed sm:left-0 sm:bottom-6 hover:bg-purple-700 lg:static lg:w-32 px-6 py-3.5 bg-purple-600 rounded-xl justify-center items-center gap-2.5 inline-flex text-center text-white text-lg font-bold font-['Pretendard'] leading-7"
+              className={`${
+                !clickedMessageIds.length ? 'cursor-not-allowed' : ''
+              } sm:w-full sm:fixed sm:left-0 sm:bottom-6 hover:bg-purple-700 lg:static lg:w-32 px-6 py-3.5 bg-purple-600 rounded-xl justify-center items-center gap-2.5 inline-flex text-center text-white text-lg font-bold font-['Pretendard'] leading-7`}
+              disabled={!clickedMessageIds.length}
             >
               저장하기
             </button>

--- a/Rolling/src/components/MessagePage/MessagePage.jsx
+++ b/Rolling/src/components/MessagePage/MessagePage.jsx
@@ -2,6 +2,7 @@ import axios from 'axios';
 import MessageCardContents from './MessageCardContents';
 import { useState, useEffect, useRef, lazy, Suspense } from 'react';
 import { useParams } from 'react-router-dom';
+import MessageLoading from './MessageLoading';
 
 const RecipientMenu = lazy(() => import('../RecipientMenu/RecipientMenu'));
 
@@ -10,6 +11,7 @@ function MessagePage() {
   const [messages, setMessages] = useState([]);
   const [offset, setOffset] = useState(0);
   const [hasNext, setHasNext] = useState(null);
+  const [loading, setLoading] = useState(false);
 
   const { id } = useParams();
   const observerRef = useRef(null);
@@ -28,6 +30,7 @@ function MessagePage() {
   useEffect(() => {
     const getRollingMessages = async () => {
       try {
+        setLoading(true);
         const response = await axios.get(
           `https://rolling-api.vercel.app/2-5/recipients/${id}/messages/?limit=${LIMIT}&offset=${offset}`
         );
@@ -41,6 +44,8 @@ function MessagePage() {
         setHasNext(next);
       } catch (error) {
         alert(error);
+      } finally {
+        setLoading(false);
       }
     };
     getRollingMessages();
@@ -88,7 +93,9 @@ function MessagePage() {
         <RecipientMenu recipient={recipient} />
       </Suspense>
       <MessageCardContents recipient={recipient} messages={messages} postId={id} />
-      <div id="observer-element" ref={observerRef}></div>
+
+      <div ref={observerRef}></div>
+      {loading && <MessageLoading />}
     </>
   );
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 요구 사항
- 요구 사항 없음.

### 변경 사항
- 편집 모드 저장하기 버튼 dsabled 및 cursor-not-allowed 추가

### 테스트 결과
- 정상적으로 동작합니다.
